### PR TITLE
Raspbian用スクリプトへbullseyeを追加

### DIFF
--- a/raspbian_all.sh
+++ b/raspbian_all.sh
@@ -15,3 +15,4 @@ if test $# -eq 0 ; then
 fi
 SCRIPT_DIR=$(cd $(dirname  $0); pwd)
 ${SCRIPT_DIR}/update_raspbian_repodb.sh -f -d buster $1/public_html/pub/Linux/raspbian
+${SCRIPT_DIR}/update_raspbian_repodb.sh -f -d bullseye $1/public_html/pub/Linux/raspbian

--- a/update_raspbian_repodb.sh
+++ b/update_raspbian_repodb.sh
@@ -37,7 +37,7 @@
 
 # Base directory of repository
 BASE_DIR=/home/openrtm/public_html/pub/Linux/raspbian
-DEFAULT_ARCHS="i386 amd64 armel armhf"
+DEFAULT_ARCHS="armhf arm64"
 #DEBUG="TRUE"
 
 #------------------------------------------------------------
@@ -68,9 +68,9 @@ get_distroseries()
 #    ALL_DISTRO=`awk 'BEGIN{RS="";FS="\n";}{sub("Dist: ",""); sub(" ","",$1); printf("%s ",$1);}END{printf("\n")}' /tmp/meta-release`
 #    SUPPORTED=`awk 'BEGIN{RS="";FS="\n";}{if ($5 == "Supported: 1"){sub("Dist: ",""); sub(" ","",$1); printf("%s ",$1);}}END{printf("\n")}' /tmp/meta-release`
 #    SUPPORTED_LIST=`awk 'BEGIN{RS="";FS="\n";}{if ($5 == "Supported: 1"){sub("Dist: ",""); sub("Version: ",""); printf("%s\t%s,",$1,$3);}}' /tmp/meta-release`
-    ALL_DISTRO="wheezy jessie stretch buster"
-    SUPPORTED="wheezy jessie stretch buster"
-    SUPPORTED_LIST="wheezy jessie stretch buster"
+    ALL_DISTRO="buster bullseye"
+    SUPPORTED="buster bullseye"
+    SUPPORTED_LIST="buster bullseye"
 }
 
 print_short_usage()


### PR DESCRIPTION
close #4 
Link to #4 

## Description of the Change

- スクリプトでは、busterとbullseyeのみサポートするようにし、古いバージョンは対象から外した
- 動作確認
  - テスト用パッケージリポジトリへbullseyeの32bit(armhf版)と64bit(arm64版)の各omniORB4.2.4のパッケージをアップロード
  - bullseyeの32, 64bitの各環境で、aptによりomniORBのパッケージをインストールできる動作を確認した

