### PR TITLE
Ubuntu用スクリプトへ22.04(jammy)を追加

### DIFF
--- a/ubuntu_all.sh
+++ b/ubuntu_all.sh
@@ -16,3 +16,4 @@ fi
 SCRIPT_DIR=$(cd $(dirname  $0); pwd)
 ${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d xenial $1/public_html/pub/Linux/ubuntu
 ${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d bionic $1/public_html/pub/Linux/ubuntu
+${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d jammy $1/public_html/pub/Linux/ubuntu


### PR DESCRIPTION
- Ubuntu用スクリプト ubuntu_all.shへ、jammyを追加した
- 動作確認
  - テスト用リポジトリへUbuntu22.04用のomniORBpy4.2.5を配置し、この修正したスクリプトでパッケージリポジトリを更新
  - Ubuntu22.04環境で、一括インストールスクリプト（openrtm2_install_ubuntu.sh）を使い、omniORBpy4.2.5パッケージのインストールを確認した