### PR TITLE
OpenRTM-aist でサポートしているUbuntu コードネームを修正

### DIFF
--- a/ubuntu_all.sh
+++ b/ubuntu_all.sh
@@ -14,6 +14,6 @@ if test $# -eq 0 ; then
     exit
 fi
 SCRIPT_DIR=$(cd $(dirname  $0); pwd)
-${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d xenial $1/public_html/pub/Linux/ubuntu
 ${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d bionic $1/public_html/pub/Linux/ubuntu
+${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d focal $1/public_html/pub/Linux/ubuntu
 ${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d jammy $1/public_html/pub/Linux/ubuntu


### PR DESCRIPTION
## Identify the Bug

- 現時点でOpenRTM-aistがサポートしているUbuntuのバージョンは、18.04，20.04，22.04
- これらのパッケージリポジトリを更新するスクリプトで定義しているコードネームが間違っていたので修正する
- これまでのパッケージリポジトリはサポートしているUbuntuバージョンのパッケージが問題なく更新されていた
- パッケージリリースでリポジトリ更新後にスクリプトをGitHubに登録した際、コードネームを間違ったようなので修正する