### PR TITLE
OpenRTM2.0.2版向けの更新

### DIFF
--- a/raspbian_all.sh
+++ b/raspbian_all.sh
@@ -14,5 +14,5 @@ if test $# -eq 0 ; then
     exit
 fi
 SCRIPT_DIR=$(cd $(dirname  $0); pwd)
-${SCRIPT_DIR}/update_raspbian_repodb.sh -f -d buster $1/public_html/pub/Linux/raspbian
 ${SCRIPT_DIR}/update_raspbian_repodb.sh -f -d bullseye $1/public_html/pub/Linux/raspbian
+${SCRIPT_DIR}/update_raspbian_repodb.sh -f -d bookworm $1/public_html/pub/Linux/raspbian

--- a/ubuntu_all.sh
+++ b/ubuntu_all.sh
@@ -14,6 +14,5 @@ if test $# -eq 0 ; then
     exit
 fi
 SCRIPT_DIR=$(cd $(dirname  $0); pwd)
-${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d bionic $1/public_html/pub/Linux/ubuntu
 ${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d focal $1/public_html/pub/Linux/ubuntu
 ${SCRIPT_DIR}/update_ubuntu_repodb.sh -f -d jammy $1/public_html/pub/Linux/ubuntu

--- a/update_raspbian_repodb.sh
+++ b/update_raspbian_repodb.sh
@@ -68,9 +68,9 @@ get_distroseries()
 #    ALL_DISTRO=`awk 'BEGIN{RS="";FS="\n";}{sub("Dist: ",""); sub(" ","",$1); printf("%s ",$1);}END{printf("\n")}' /tmp/meta-release`
 #    SUPPORTED=`awk 'BEGIN{RS="";FS="\n";}{if ($5 == "Supported: 1"){sub("Dist: ",""); sub(" ","",$1); printf("%s ",$1);}}END{printf("\n")}' /tmp/meta-release`
 #    SUPPORTED_LIST=`awk 'BEGIN{RS="";FS="\n";}{if ($5 == "Supported: 1"){sub("Dist: ",""); sub("Version: ",""); printf("%s\t%s,",$1,$3);}}' /tmp/meta-release`
-    ALL_DISTRO="buster bullseye"
-    SUPPORTED="buster bullseye"
-    SUPPORTED_LIST="buster bullseye"
+    ALL_DISTRO="bullseye bookworm"
+    SUPPORTED="bullseye bookworm"
+    SUPPORTED_LIST="bullseye bookworm"
 }
 
 print_short_usage()


### PR DESCRIPTION
- OpenRTM2.0.2版リリース時点でサポートしているディストリビューション向けに整備した
  - Ubuntuのサポート対象：　focal(20.04)、jammy(22.04)
  - Raspbianのサポート対象：　bullseye、bookworm
  - サポート対象外（buster, bionic）の設定は削除した